### PR TITLE
[#8]:svarga:docs, add usage examples

### DIFF
--- a/docs/scaled.md
+++ b/docs/scaled.md
@@ -2,184 +2,132 @@
 
 ## Overview
 
-`scaled.hpp` implements a minimal, allocation-free numeric type based on a canonical triplet:
+`math::scaled::decimal_t<significand_t, exponent_t>` is a minimal, allocation-free decimal type based on a (significand, exponent) pair:
 
-[
-x = (\texttt{category}, m, e), \quad m \in \mathbb{N},\ e \in \mathbb{Z}
-]
+$$x = m \cdot 10^e, \quad m \in \mathbb{Z},\ e \in \mathbb{Z}$$
 
-* **category** ∈ { `positive`, `negative`, `zero`, `pinf`, `ninf`, `nan` }
-* **significand** `m` stored as unsigned integer
-* **exponent** `e` stored as signed integer
-
-Sign is carried exclusively by `category`.
+Sign is encoded directly in the significand (when `significand_t` is signed). There are no NaN or Inf values — the type operates in the finite domain only.
 
 ---
 
-## Representation
+## Declaration
 
 ```cpp
-struct scaled_t {
-    category kind;
-    significand_t m;
-    exponent_t e;
-};
+namespace math::scaled {
+    template <class significand_t, class exponent_t = std::int16_t>
+    struct decimal_t;
+}
 ```
 
-### Invariants
-
-* `kind == zero`  ⇒ `m = 0`, `e = 0`
-* `kind ∈ {positive, negative}` ⇒ `m > 0`
-* `kind ∈ {pinf, ninf, nan}` ⇒ `m = 0`, `e = 0` (ignored)
-* no sign encoded in `m`
-
----
-
-## Semantics
-
-### Finite values
-
-[
-x =
-\begin{cases}
-+m \cdot B^e & \text{if } kind = positive \
--m \cdot B^e & \text{if } kind = negative
-\end{cases}
-]
-
-`B` is the implicit radix (typically 10 or 2 depending on context).
-
----
-
-### Special values
-
-| category | meaning      |
-| -------- | ------------ |
-| `zero`   | exact 0      |
-| `pinf`   | +∞           |
-| `ninf`   | −∞           |
-| `nan`    | not-a-number |
-
----
-
-## Decomposition
-
-```cpp
-auto [kind, m, e] = decompose(x);
-```
-
-* exact for all finite values
-* canonical:
-
-  * zero → `{zero, 0, 0}`
-  * no signed zero
-* matches `decimal.hpp` and IEEE-754 decomposition (`utils.hpp`)
+`significand_t` must be integral. Signed `significand_t` gives full positive/negative range. Unsigned restricts to non-negative values.
 
 ---
 
 ## Construction
 
 ```cpp
-scaled_t x{category::positive, m, e};
+using d64 = math::scaled::decimal_t<int64_t>;
+
+d64 x{12345, -2};           // 123.45  (significand=12345, exponent=-2)
+d64 y{-50,   -2};           // -0.50
+d64 z{};                    // 0
+
+explicit d64 from_int{42};  // significand=42, exponent=0
 ```
 
-or via helpers:
+Construction calls `normalize()` which strips trailing decimal zeros from the significand, incrementing the exponent accordingly:
 
 ```cpp
-make(m, e)          // finite
-make_zero()
-make_inf(sign)
-make_nan()
+d64{1000, -3}  →  {1, 0}    // 1.000 → 1e0
+d64{500,  -2}  →  {5, -1}   // 5.00  → 5e-1
 ```
 
 ---
 
-## Normalization
+## Arithmetic
 
-Normalization enforces:
+```cpp
+d64 a{12345, -2};   // 123.45
+d64 b{50,    -2};   //   0.50
 
-* `m = 0` ⇒ `zero`
-* no redundant representations
-* optional trimming of trailing base factors:
-  [
-  m \cdot B^e \rightarrow (m', e') \quad \text{with } \gcd(m', B)=1
-  ]
+d64 sum  = a + b;   // 123.95  — exponent aligned, widened intermediate
+d64 diff = a - b;   // 122.95
+d64 prod = a * b;   //  61.725 — exponents add
+d64 quot = a / b;   // 246     — integer division of aligned significands
+```
 
----
-
-## Arithmetic (finite domain)
-
-Operations defined on `{positive, negative, zero}`:
-
-* addition / subtraction: exponent alignment
-* multiplication:
-  [
-  (m_1,e_1)\cdot(m_2,e_2) = (m_1 m_2,\ e_1 + e_2)
-  ]
-* division (if supported): inverse scaling
-
-Special values may:
-
-* propagate (`nan`)
-* saturate (`±inf`)
-* or be rejected (implementation-defined)
+Addition and subtraction align exponents using `__int128` widening to avoid intermediate overflow. Multiplication adds exponents. Division is integer quotient only — no fractional rescue.
 
 ---
 
 ## Comparison
 
+`operator<=>` returns `std::strong_ordering` (not `partial_ordering`):
+
 ```cpp
-std::partial_ordering
+d64 p{100, -2};   // 1.00
+d64 q{1,    0};   // 1
+
+bool eq = (p == q);                               // true — aligned comparison
+auto ord = (p <=> q);                             // strong_ordering::equal
 ```
 
-* `nan` is unordered
-* otherwise lexicographic after exponent alignment
+`operator==` also aligns exponents before comparing.
 
 ---
 
-## Properties
+## Decomposition
 
-* **exact arithmetic** (no rounding unless explicitly introduced)
-* **deterministic layout** (POD / trivially serializable)
-* **no hidden state** (no implicit normalization assumptions)
-* **branch-light decomposition**
-* suitable for:
-
-  * financial math
-  * serialization / hashing
-  * deterministic replay
-  * ZK-friendly representations
+```cpp
+auto [sig, exp] = x.as_pair();   // std::pair<significand_t, exponent_t>
+```
 
 ---
 
-## Relationship to other components
+## Utilities
 
-* `decimal.hpp` → hardware/BID-backed decimal FP
-* `utils.hpp` → IEEE-754 float decomposition
-* `scaled.hpp` → integer-backed canonical representation
+```cpp
+// Absolute value (requires signed significand_t)
+d64 abs_val = math::scaled::abs(x);
 
-All share:
+// Conversion to floating-point
+double d  = static_cast<double>(x);
+float  f  = static_cast<float>(x);
+auto   ld = static_cast<long double>(x);
 
-[
-x \leftrightarrow (\texttt{category}, m, e)
-]
+// String representation
+std::string s = static_cast<std::string>(x);   // "12345e-2"
+
+// Checksum (for hashing / verification)
+uint64_t h = math::scaled::checksum(x);
+```
 
 ---
 
-## Notes
+## Relationship to other types
 
-* collapses `+0` and `-0` → `zero`
-* not a full IEEE-754 model (by design)
-* exponent range depends on `exponent_t`
-* overflow behavior depends on `significand_t`
+| | `math::decimal_t` | `math::bcd::decimal_t` | `math::fixed::decimal_t` | `math::scaled::decimal_t` |
+|---|:---:|:---:|:---:|:---:|
+| NaN / Inf | yes | yes | yes | **no** |
+| Category field | yes | yes | yes | **no** |
+| Exponent | runtime | runtime | **compile-time** | runtime |
+| Sign encoding | category | category | category | **significand** |
+| Ordering | partial | partial | partial | **strong** |
+| External dep | LIBBID | none | none | none |
 
 ---
 
 ## Minimal example
 
 ```cpp
-scaled_t x{category::positive, 12345, -2}; // 123.45
+#include <decimal/scaled.hpp>
 
-auto [c, m, e] = decompose(x);
-// c = positive, m = 12345, e = -2
+using price_t = math::scaled::decimal_t<int64_t>;
+
+price_t bid{10250, -2};   // 102.50
+price_t ask{10275, -2};   // 102.75
+price_t spread = ask - bid;
+
+auto [sig, exp] = spread.as_pair();
+// sig = 25, exp = -2  →  0.25
 ```

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,0 +1,155 @@
+# Decimal Type Selection Guide
+
+libdecimal provides four decimal representations. This guide helps you pick the right one.
+
+---
+
+## Decision Matrix
+
+| Need | Use |
+|---|---|
+| Full IEEE 754-2008 compliance, transcendentals, audit trail | `math::decimal_t<T>` (BID) |
+| Compile-time fixed scale, constexpr, zero overhead | `math::fixed::decimal_t<T, exponent>` |
+| Exact arithmetic, pure C++, no Intel LIBBID dependency | `math::bcd::decimal_t<T>` |
+| Lightweight (significand, exponent) pair, serialization | `math::scaled::decimal_t<T>` |
+
+---
+
+## `math::decimal_t<T>` — BID (Binary Integer Decimal)
+
+**When to use:** You need full IEEE 754-2008 decimal semantics — transcendentals, NaN/Inf propagation, exchange-compatible arithmetic, or auditability.
+
+```cpp
+#include <decimal/bid.hpp>
+using namespace math::literals;
+
+// Construction
+math::decimal_t<uint64_t> price(12345, -2);   // 123.45
+auto fee = "0.0025"_dec;                       // string literal
+auto total = price * fee;                      // exact
+
+// Transcendentals
+auto result = math::exp(price);
+
+// Formatting
+std::println("{}", price);     // "123.45"
+
+// Precisions: decimal_t<uint32_t> = 7 digits, <uint64_t> = 16, <BID_UINT128> = 34
+```
+
+**Strengths:** Intel LIBBID-backed, full operator set, `std::formatter`, UDLs (`_dec32`, `_dec64`, `_dec128`, `_dec`), math constants at all three precisions, DPD↔BID conversion.
+
+**Trade-offs:** Requires linking Intel LIBBID (`libbid_static`).
+
+---
+
+## `math::fixed::decimal_t<T, exponent>` — Fixed-Point
+
+**When to use:** The decimal scale is known at compile time (e.g., always 4 decimal places for currency). Constexpr context, embedded, or you need zero-overhead arithmetic.
+
+```cpp
+#include <decimal/fixed.hpp>
+using price_t = math::fixed::decimal_t<uint64_t, -4>;  // 4 decimal places
+
+price_t p{math::bid::category::positive, 1234567};  // 123.4567
+price_t q{math::bid::category::positive, 9999};     // 0.9999
+price_t sum = p + q;                                // 124.4566, overflow-checked
+
+// Decompose
+auto [kind, significand, exp] = p.decompose();
+// kind = positive, significand = 1234567, exp = -4 (compile-time constant)
+
+// Constexpr
+static_assert(price_t::exponent_v == -4);
+static_assert(price_t::scale_factor_v == 10000);
+```
+
+**Strengths:** No external dependency, `constexpr`, widened-intermediate overflow detection (`uint128_t` for 64-bit), `checksum()`.
+
+**Trade-offs:** Exponent is baked into the type — you cannot mix scales without a cast.
+
+---
+
+## `math::bcd::decimal_t<T>` — Binary Coded Decimal
+
+**When to use:** You need exact decimal arithmetic without Intel LIBBID, or you need digit-level access (nibble-packed storage), or you are targeting an environment where LIBBID is unavailable.
+
+```cpp
+#include <decimal/bcd.hpp>
+using bcd64 = math::bcd::decimal_t<uint64_t>;
+
+bcd64 a{123456789ull};          // positive, exponent = 0
+bcd64 b{"987654321", -3};       // 987654.321, from string
+bcd64 sum = a + b;              // exact, overflow-checked
+
+// Digit-level: packed as nibbles in significand_t
+auto [kind, significand, exp] = a.decompose();
+
+// String representation
+std::string s = a.str();        // "123456789e0"
+
+// Supports: +, -, *, /, ==, <=>, str(), to_long_double(), checksum()
+```
+
+**Strengths:** Pure C++ (no LIBBID), runtime exponent, `constexpr`-friendly operations, BCD digit access via `packed_bcd()`.
+
+**Trade-offs:** Slower than BID for bulk arithmetic (nibble-pack/unpack per operation); no transcendentals.
+
+---
+
+## `math::scaled::decimal_t<T>` — Scaled Integer
+
+**When to use:** You need a lightweight (significand, exponent) pair — wire format, serialization, hash keys, or intermediate representations where NaN/Inf semantics are not required.
+
+```cpp
+#include <decimal/scaled.hpp>
+using scaled64 = math::scaled::decimal_t<int64_t>;
+
+scaled64 x{12345, -2};    // 123.45
+scaled64 y{50, -2};       // 0.50
+scaled64 sum = x + y;     // 123.95 (exponent-aligned)
+
+// Signed significand encodes sign directly
+scaled64 neg{-12345, -2}; // -123.45
+scaled64 abs_val = math::scaled::abs(neg);
+
+// Decompose
+auto [sig, exp] = x.as_pair();
+
+// Comparison (strong_ordering — no NaN)
+bool less = (x < y);
+
+// Checksum for hashing/verification
+uint64_t h = math::scaled::checksum(x);
+```
+
+**Strengths:** Minimal footprint, no NaN/Inf overhead, `strong_ordering` (not `partial_ordering`), signed or unsigned significand, `checksum()`.
+
+**Trade-offs:** No NaN/Inf — not IEEE 754. Division truncates (integer quotient). No string parsing constructor.
+
+---
+
+## Shared Infrastructure
+
+All four types share `math::bid::category`:
+
+```cpp
+enum struct category : unsigned char {
+    positive = 0b0000, negative = 0b0001,
+    pinf     = 0b0010, ninf     = 0b0011,
+    nan      = 0b0100, zero     = 0b1000
+};
+```
+
+BID, BCD, and fixed types all use this enum for their `kind` field. Code that inspects `math::bid::category` works uniformly across the family.
+
+---
+
+## Summary
+
+```
+Need NaN/Inf + transcendentals?  ──→  math::decimal_t  (BID)
+Fixed scale, constexpr?           ──→  math::fixed::decimal_t
+Pure C++, digit access?           ──→  math::bcd::decimal_t
+Lightweight pair, serialization?  ──→  math::scaled::decimal_t
+```


### PR DESCRIPTION
## Summary
- `docs/types.md` — new type-selection guide: decision matrix + one working example per representation (BID, fixed, BCD, scaled)
- `docs/scaled.md` — replaced stale dev-era spec (described wrong API with `kind` field and `make_zero()`/`make_inf()` helpers that don't exist) with accurate `math::scaled::decimal_t` documentation

## Test plan
- [ ] `mkdocs serve` renders both pages without errors
- [ ] All code snippets in `docs/types.md` compile against current staging headers
- [ ] `docs/scaled.md` API matches `include/decimal/scaled.hpp` (no phantom fields or helpers)