### PR TITLE
[#10]:svarga:ci, add sanitizers and coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,52 @@ jobs:
           publish_dir: ./${{ steps.badge_dir.outputs.dir }}
           destination_dir: ${{ steps.badge_dir.outputs.dir }}
 
+  sanitizers:
+    name: sanitizers / ubuntu-24.04 / clang-19
+    runs-on: ubuntu-24.04
+
+    env:
+      CC: clang-19
+      CXX: clang++-19
+      ASAN_OPTIONS: halt_on_error=1:detect_leaks=1
+      UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build gcc-13 g++-13
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          codename="$(. /etc/os-release && echo "$VERSION_CODENAME")"
+          sudo DISTRIB_CODENAME="$codename" ./llvm.sh 19 all
+
+      - name: Configure
+        shell: bash
+        run: |
+          gcc_root="$(dirname "$(dirname "$(readlink -f "$(command -v g++-13)")")")"
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_COMPILER=clang-19 \
+            -DCMAKE_CXX_COMPILER=clang++-19 \
+            -DCMAKE_C_FLAGS="--gcc-toolchain=$gcc_root" \
+            -DCMAKE_CXX_FLAGS="--gcc-toolchain=$gcc_root -stdlib=libstdc++" \
+            -DCMAKE_EXE_LINKER_FLAGS="--gcc-toolchain=$gcc_root -stdlib=libstdc++"
+
+      - name: Build
+        shell: bash
+        run: cmake --build build --parallel
+
+      - name: Test (ASan + UBSan)
+        shell: bash
+        run: ctest --test-dir build --output-on-failure --parallel
+
   coverage:
     name: coverage / ubuntu-24.04 / gcc-14
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
- Add `sanitizers` job to CI: ubuntu-24.04 / clang-19 / `CMAKE_BUILD_TYPE=Debug`
- `ASAN_OPTIONS=halt_on_error=1:detect_leaks=1` and `UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1` set at job level
- Sanitizers activate automatically via existing CMakeLists.txt logic (`-fsanitize=address,undefined` applied to all test targets in Debug+GCC/Clang builds)
- Coverage job already present; this PR adds only the missing sanitizer pass

## Test plan
- [ ] CI `sanitizers` job passes on this branch
- [ ] No sanitizer violations reported in test output
- [ ] Existing `build` matrix and `coverage` jobs unaffected